### PR TITLE
(#22) standardise the agent name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Once embedded you can manage your fleet with commands like this:
 Pause, resume and request info for all services in `DC1`
 
 ```
-$ mco rpc myapp pause -W dc=DC1
+$ mco rpc backplane pause -W dc=DC1
 ```
 
 ```
-$ mco rpc myapp resume -W dc=DC1
+$ mco rpc backplane resume -W dc=DC1
 ```
 
 ```
-$ mco rpc myapp health -W dc=DC1
+$ mco rpc backplane health -W dc=DC1
 ```
 
 [![GoDoc](https://godoc.org/github.com/choria-io/go-backplane?status.svg)](https://godoc.org/github.com/choria-io/go-backplane)
@@ -200,7 +200,7 @@ interval: 600
 
 # Standard Backplane specific configuration here
 management:
-    collective: app
+    name: app
     logfile: "/var/log/app/backplane.log"
     loglevel: warn
     tls:
@@ -262,7 +262,7 @@ func (a *App) startBackPlane(ctx context.Context, wg *sync.Waitgroup) error {
             backplane.ManageStopable(a),
         }
 
-        _, err := backplane.Run(ctx, wg, "app", a.config.Management, opts...)
+        _, err := backplane.Run(ctx, wg, a.config.Management, opts...)
         if err != nil {
             return err
         }
@@ -272,19 +272,8 @@ func (a *App) startBackPlane(ctx context.Context, wg *sync.Waitgroup) error {
 }
 ```
 
-Once you call `startBackPlane()` in your startup cycle it will start a Choria instance with the `discovery`, `choria_util` and `app` agents, the app agent will have all the actions listed in the earlier table, your config will be shown in the `info` action and you can discovery it using any of the facts.
+Once you call `startBackPlane()` in your startup cycle it will start a Choria instance with the `discovery`, `choria_util` and `backplane` agents, the `backplane` agent will have all the actions listed in the earlier table, your config will be shown in the `info` action and you can discovery it using any of the facts.
 
 If you only supply some of `ManageInfoSource`, `ManagePausable`, `ManageHealthCheck` and `ManageStopable` the features of the agent will be selectively disabled as per the table earlier.
 
-### Configuring Choria CLI and API clients
-
-To interact with the service from the CLI, Ruby Client API or Choria Go Client API you need a description of the service.
-
-A tool to create these are included and you should distribute these files to your client in the Choria lib directories - typically `/opt/puppetlabs/mcollective/plugins/mcollective/agent`.
-
-```
-$ go get github.com/choria-io/go-backplane/cmd/backplane
-$ backplane generate --name yourapp --cron --health --stop
-```
-
-You'll now have `yourapp.json` and `yourapp.ddl` in the current directory, distribute those files to your library dirs as with any other Choria agent.
+All backplane managed services will use the `backplane` agent name, to differentiate the `name` will be used to construct a sub collective name so each app is effectively contained. The upcoming CLI will be built around this design.

--- a/agent.go
+++ b/agent.go
@@ -13,19 +13,28 @@ import (
 
 // Pausable is a service that can be paused
 type Pausable interface {
+	// Pause should pause operations within your app immediately
 	Pause()
+
+	// Resume should resume operations within your app immediately
 	Resume()
+
+	// Flip should invert the pause state in an atomic manner
 	Flip()
+
+	// Should report the pause state
 	Paused() bool
 }
 
 // HealthCheckable describes a application that can be checked using the backplane
 type HealthCheckable interface {
+	// HealthCheck should return as its result a struct that can be JSON converted
 	HealthCheck() (result interface{}, ok bool)
 }
 
 // Stopable describes an application that can be stopped using the backplane
 type Stopable interface {
+	// Shutdown will be called after some delay and should exit the application
 	Shutdown()
 }
 

--- a/auth.go
+++ b/auth.go
@@ -4,9 +4,14 @@ import "regexp"
 
 // Authorization lists certificate names that may access the backplane
 type Authorization struct {
-	Insecure bool     `json:"insecure" yaml:"insecure"`
-	Full     []string `json:"full" yaml:"full"`
-	RO       []string `json:"read_only" yaml:"read_only"`
+	// Insecure disables security and allow all callers to do anything
+	Insecure bool `json:"insecure" yaml:"insecure"`
+
+	// Full is a regex list of certnames that can perform changes like pause and resume
+	Full []string `json:"full" yaml:"full"`
+
+	// RO is a regex list of certnames that can request information from the service
+	RO []string `json:"read_only" yaml:"read_only"`
 }
 
 // ROAllowed determines if this user can access read only action

--- a/backplane.go
+++ b/backplane.go
@@ -6,11 +6,11 @@
 // You will be able to interact with your application from the Choria CLI, Ruby API or Go API and
 // perform some or all of the below
 //
-//  * Circuit Breaker that can pause and resume your application
-//  * Healthchecks to query the internal health of your application
-//  * Stop the application
+// * Circuit Breaker that can pause and resume your application
+// * Healthchecks to query the internal health of your application
+// * Shutdown the application
 //
-// Additionally data about your application like it's configuration will be exposed to the Choria
+// Additionally data about your application like it's configuration can be exposed to the Choria
 // discovery subsystem
 package backplane
 
@@ -38,12 +38,12 @@ type Management struct {
 }
 
 // Run creates a new instance of the backplane
-func Run(ctx context.Context, wg *sync.WaitGroup, name string, conf ConfigProvider, opts ...Option) (m *Management, err error) {
+func Run(ctx context.Context, wg *sync.WaitGroup, conf ConfigProvider, opts ...Option) (m *Management, err error) {
 	m = &Management{
 		mu: &sync.Mutex{},
 	}
 
-	m.cfg, err = newConfig(name, conf, opts...)
+	m.cfg, err = newConfig("backplane", conf, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize Choria backplane: %s", err)
 	}

--- a/cmd/backplane/backplane.go
+++ b/cmd/backplane/backplane.go
@@ -20,7 +20,6 @@ func main() {
 	app.Author("R.I.Pienaar <rip@devco.net>")
 
 	g := app.Command("generate", "Generates DDL files for the backplane generated agents")
-	g.Flag("name", "Agent name to generate").Required().StringVar(&name)
 	g.Flag("pause", "Generate actions for the Pausable interface").BoolVar(&pausable)
 	g.Flag("stop", "Generate actions for the Stopable interface").BoolVar(&stopable)
 	g.Flag("health", "Generate actions for the HealthCheckable interface").BoolVar(&healthable)

--- a/cmd/backplane/generate.go
+++ b/cmd/backplane/generate.go
@@ -33,14 +33,14 @@ func generate() {
 }
 
 func generateDDL() error {
-	out := name + ".ddl"
+	out := "backplane.ddl"
 
 	if _, err := os.Stat(out); err == nil {
 		return fmt.Errorf("%s already exist", out)
 	}
 
 	d := ddl{
-		Name:    name,
+		Name:    "backplane",
 		Version: backplane.Version,
 		Pause:   pausable,
 		Health:  healthable,
@@ -68,7 +68,7 @@ func generateDDL() error {
 }
 
 func generateJSON() error {
-	out := name + ".json"
+	out := "backplane.json"
 
 	if _, err := os.Stat(out); err == nil {
 		return fmt.Errorf("%s already exist", out)
@@ -76,7 +76,7 @@ func generateJSON() error {
 
 	ddl := agent.DDL{
 		Metadata: &agents.Metadata{
-			Name:        name,
+			Name:        "backplane",
 			Description: "Choria Management Backplane",
 			Author:      "R.I.Pienaar <rip@devco.net>",
 			Version:     backplane.Version,

--- a/example/backplane.ddl
+++ b/example/backplane.ddl
@@ -1,9 +1,9 @@
 
-metadata    :name        => "app",
+metadata    :name        => "backplane",
             :description => "Choria Management Backplane",
             :author      => "R.I.Pienaar <rip@devco.net>",
             :license     => "Apache-2.0",
-            :version     => "0.0.1",
+            :version     => "0.0.2",
             :url         => "https://choria.io/",
             :timeout     => 10
 

--- a/example/backplane.json
+++ b/example/backplane.json
@@ -4,8 +4,8 @@
       "license": "Apache-2.0",
       "author": "R.I.Pienaar \u003crip@devco.net\u003e",
       "timeout": 10,
-      "name": "app",
-      "version": "0.0.1",
+      "name": "backplane",
+      "version": "0.0.2",
       "url": "https://choria.io",
       "description": "Choria Management Backplane"
    },

--- a/example/myapp.go
+++ b/example/myapp.go
@@ -92,7 +92,7 @@ func main() {
 		backplane.ManageStopable(app),
 	}
 
-	_, err = backplane.Run(ctx, wg, "app", app.config.Management, opts...)
+	_, err = backplane.Run(ctx, wg, app.config.Management, opts...)
 	if err != nil {
 		log.Fatalf("Could not start backplane: %s", err)
 	}

--- a/facts.go
+++ b/facts.go
@@ -12,7 +12,11 @@ import (
 
 // InfoSource supplies fact data
 type InfoSource interface {
+	// FactData should return any data you wish to expose to the fact system, it should
+	// be a JSON serializable struct and it's best if its a flat one with k=v pairs
 	FactData() interface{}
+
+	// Version is any version string of your application
 	Version() string
 }
 

--- a/standardconfiguration.go
+++ b/standardconfiguration.go
@@ -5,7 +5,7 @@ package backplane
 // to give users the ability to configure the backplane
 type StandardConfiguration struct {
 	Brokers       []string      `json:"brokers" yaml:"brokers"`
-	Collective    string        `json:"collective" yaml:"collective"`
+	AppName       string        `json:"name" yaml:"name"`
 	LogFilePath   string        `json:"logfile" yaml:"logfile"`
 	Loglevel      string        `json:"loglevel" yaml:"loglevel"`
 	TLSConf       *TLSConf      `json:"tls" yaml:"tls"`
@@ -17,9 +17,9 @@ func (s *StandardConfiguration) MiddlewareHosts() []string {
 	return s.Brokers
 }
 
-// Collectives is a list of collectives to join, the first will be the main collective
-func (s *StandardConfiguration) Collectives() []string {
-	return []string{s.Collective}
+// Name is a name for the application which will be used as a name for the collective the nodes are in
+func (s *StandardConfiguration) Name() string {
+	return s.AppName
 }
 
 // LogFile is the file to log to


### PR DESCRIPTION
In order to improve the story for writing clients and distributing
DDLs etc it's best to stick to one agent name, instead of different
agents we'll stick the same agent in different sub collectives

Later a CLI might look like `backplane cron pause` which means run
the `pause` action within the cron_backplane subcollective and so
would `mco rpc bacplane pause -T cron_backplane`.

The reason we need this seperation is so that multiple managed services
on the same node do not all present the same hostname in the same
collective which would not work too well